### PR TITLE
Add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+cff-version: 1.2.0
+message: "If you use ActPlane in your research, please cite the arXiv preprint."
+title: "ActPlane"
+type: software
+version: "0.1.8"
+license: MIT
+repository-code: "https://github.com/eunomia-bpf/ActPlane"
+url: "https://github.com/eunomia-bpf/ActPlane"
+authors:
+  - family-names: Zheng
+    given-names: Yusheng
+  - family-names: Wu
+    given-names: Tianyuan
+  - family-names: Fu
+    given-names: Quanzhi
+  - family-names: Yu
+    given-names: Tong
+  - family-names: Mao
+    given-names: Wenan
+  - family-names: Wang
+    given-names: Wei
+  - family-names: Williams
+    given-names: Dan
+  - family-names: Quinn
+    given-names: Andi
+keywords:
+  - AI agents
+  - eBPF
+  - information-flow control
+  - policy enforcement
+preferred-citation:
+  type: article
+  title: "ActPlane: Programmable OS-Level Policy Enforcement for Agent Harnesses"
+  authors:
+    - family-names: Zheng
+      given-names: Yusheng
+    - family-names: Wu
+      given-names: Tianyuan
+    - family-names: Fu
+      given-names: Quanzhi
+    - family-names: Yu
+      given-names: Tong
+    - family-names: Mao
+      given-names: Wenan
+    - family-names: Wang
+      given-names: Wei
+    - family-names: Williams
+      given-names: Dan
+    - family-names: Quinn
+      given-names: Andi
+  year: 2026
+  date-published: "2026-06-23"
+  url: "https://arxiv.org/abs/2606.25189"
+  identifiers:
+    - type: other
+      value: "arXiv:2606.25189"
+      description: "arXiv identifier"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ActPlane: eBPF-Based IFC Policy Engine for AI Agent Harnesses
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![arXiv](https://img.shields.io/badge/arXiv-2606.25189-b31b1b.svg)](https://arxiv.org/abs/2606.25189)
 
 **Runtime `enforcement` and `observability` for AI agent harnesses and sandboxing: declare information-flow policies for safety, security and compliance, and ActPlane enforces them in the kernel with eBPF.**
 
@@ -277,3 +278,19 @@ sudo bash script/e2e_examples.sh   # live E1–E12 enforcement
 ## LICENSE
 
 MIT License. See [LICENSE](LICENSE).
+
+## Cite the Project
+
+If ActPlane helps your research, please cite the arXiv preprint:
+
+```bibtex
+@misc{zheng2026actplane,
+  title = {ActPlane: Programmable OS-Level Policy Enforcement for Agent Harnesses},
+  author = {Yusheng Zheng and Tianyuan Wu and Quanzhi Fu and Tong Yu and Wenan Mao and Wei Wang and Dan Williams and Andi Quinn},
+  year = {2026},
+  eprint = {2606.25189},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.OS},
+  url = {https://arxiv.org/abs/2606.25189}
+}
+```


### PR DESCRIPTION
## Summary

- Add an arXiv badge for the ActPlane preprint to the README.
- Add a short README citation section with BibTeX.
- Add `CITATION.cff` so GitHub can expose the repository citation button.

## Validation

- `git diff --check origin/master..HEAD`
- Parsed `CITATION.cff` with Ruby YAML and verified the arXiv identifier.