### PR TITLE
Adopt PR-only workflow for ActPlane experiments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,17 +19,18 @@ The repo descends from AgentSight (an eBPF observability framework); the SSL/HTT
 analyzer chain, runners, web server, and frontend were removed. What remains is the
 labeled information-flow engine plus a minimal Rust compiler/driver.
 
-## Agent behavioral constraints (ActPlane-applied)
+## Agent change workflow
 
-When acting as an agent in this repo, **do not run `git branch` or `git worktree`** —
-the user does not want new branches or worktrees created right now. **Other git
-operations are allowed** (`git commit`, `git add`, `git status`, `git log`, `git push`,
-…). If you think a different branch is needed, ask the user instead of creating one.
+Develop experiments and other changes on a dedicated non-default branch in this
+existing checkout. Changes entering the default `master` branch require a pull
+request. Do not push implementation or experiment commits directly to `master`.
+Creating and using a task branch is authorized, but do not create an additional
+worktree unless the user explicitly requests one.
 
-`git branch` and `git worktree` are also applied below the tool layer by ActPlane
-itself (`actplane.yaml`, rule `no-git-branch`, `kill exec "git" "branch"`/`kill exec "git" "worktree"`): they
-are killed whether invoked via a tool call, `bash -c`, or a subprocess — a worked
-example of a real corpus-derived guardrail in the taint DSL.
+The repository still includes `no-git-branch` templates, examples, and test
+fixtures as demonstrations of ActPlane policy behavior. They are product assets,
+not an operational prohibition for this checkout, and should not be removed merely
+because this workspace now uses branches.
 
 When an operation fails with `EPERM` / `Operation not permitted`, or a tool hook
 injects an `[ActPlane]` message, treat it as authoritative kernel feedback. Read

--- a/actplane.yaml
+++ b/actplane.yaml
@@ -7,12 +7,6 @@ policy: |
   source AGENT = exec "**/claude"
   source AGENT = exec "**/codex"
 
-  # No new branches or worktrees.
-  rule no-git-branch:
-    kill exec "git" "branch"   if AGENT
-    kill exec "git" "worktree" if AGENT
-    because "This workspace forbids creating git branches or worktrees. Use other git commands, or ask the user to manage branches."
-
   # No auto-commit — agent must not commit without explicit user approval.
   # Gate: write .actplane/commit-approved to signal user approval; re-arms after each commit.
   rule no-auto-commit:

--- a/bpf/src/lib.rs
+++ b/bpf/src/lib.rs
@@ -1288,9 +1288,7 @@ fn tracepoint_needed(spec: &TracepointSpec, budget: HookBudget, legacy: bool) ->
         TracepointNeed::ExecArgs => true,
         TracepointNeed::FileOpen => budget.has_file_flow() || budget.has_open_rules(),
         TracepointNeed::FileWritePath => budget.has_file_write() || budget.has_file_flow(),
-        TracepointNeed::RenameRuleExit => {
-            legacy || budget.has_write_rules()
-        }
+        TracepointNeed::RenameRuleExit => legacy || budget.has_write_rules(),
         TracepointNeed::RenameFlowExit => {
             !legacy && budget.has_file_flow() && !budget.has_write_rules()
         }
@@ -3073,10 +3071,18 @@ mod tests {
         assert!(tracepoint_needed(spec("trace_openat"), file, false));
         assert!(tracepoint_needed(spec("trace_read_exit"), file, false));
         assert!(tracepoint_needed(spec("trace_unlink"), file, false));
-        assert!(tracepoint_needed(spec("trace_rename_exit_flow"), file, false));
+        assert!(tracepoint_needed(
+            spec("trace_rename_exit_flow"),
+            file,
+            false
+        ));
         assert!(!tracepoint_needed(spec("trace_rename_exit"), file, false));
         assert!(tracepoint_needed(spec("trace_rename_exit"), file, true));
-        assert!(!tracepoint_needed(spec("trace_rename_exit_flow"), file, true));
+        assert!(!tracepoint_needed(
+            spec("trace_rename_exit_flow"),
+            file,
+            true
+        ));
         assert!(!tracepoint_needed(spec("trace_pipe"), file, false));
         assert!(!tracepoint_needed(spec("trace_mmap"), file, false));
 
@@ -3101,7 +3107,11 @@ mod tests {
         };
         assert!(tracepoint_needed(spec("trace_pipe"), advanced_file, false));
         assert!(tracepoint_needed(spec("trace_mmap"), advanced_file, false));
-        assert!(tracepoint_needed(spec("trace_recvmsg"), advanced_file, false));
+        assert!(tracepoint_needed(
+            spec("trace_recvmsg"),
+            advanced_file,
+            false
+        ));
     }
 
     #[test]

--- a/docs/empirical-study/rq2-reviewer-audit-plan.md
+++ b/docs/empirical-study/rq2-reviewer-audit-plan.md
@@ -192,6 +192,31 @@ OPAQUE remains a feedback ablation, while prompt-filter and tool-regex remain we
 configured controls. Therefore the existing evidence does not support claiming an
 independent strong-baseline comparison on unseen non-coding tasks.
 
+A forensic check of both documented backups narrows, but does not remove, the raw
+evidence gap. `origin/backup/2026-06-14-master` contains no OpenAgentSafety result
+directories. The separately backed-up official benchmark repository at commit
+`8cb4131211435a933d44942479e79418972f8f9b` retains per-task trajectories and
+evaluator outputs for its published model runs. It does not retain the ActPlane
+condition's per-task watcher logs, runner summaries, or matched trajectories used
+to produce the paper's aggregate 78/28 count. Those official files can support a
+future frozen task selection and baseline audit, but cannot reconstruct ActPlane's
+per-task outcomes or turn the no-enforcement condition into an independent method.
+
+The forensic commands are:
+
+```bash
+git ls-tree -r --name-only origin/backup/2026-06-14-master \
+  docs/OpenAgentSafety
+git ls-remote https://github.com/eunomia-bpf/OpenAgentSafety.git \
+  refs/heads/backup/2026-06-14-actplane-submodule
+# inspect the recursive Git tree for nested commit 8cb4131 via the GitHub API
+```
+
+An independent local-model assessment attempt is retained under
+`/workspaces/.agent-state/actplane-research/raw/oas-forensic-review-20260910/`.
+Provider errors, if any, remain part of that raw record and are not treated as a
+successful review.
+
 A defensible next experiment would freeze a task-description-only policy generator
 and an unseen OpenAgentSafety subset, then compare ActPlane with an official,
 independently implemented runtime policy method under the same tasks, model,

--- a/docs/empirical-study/rq2-reviewer-audit-plan.md
+++ b/docs/empirical-study/rq2-reviewer-audit-plan.md
@@ -212,11 +212,6 @@ git ls-remote https://github.com/eunomia-bpf/OpenAgentSafety.git \
 # inspect the recursive Git tree for nested commit 8cb4131 via the GitHub API
 ```
 
-An independent local-model assessment attempt is retained under
-`/workspaces/.agent-state/actplane-research/raw/oas-forensic-review-20260910/`.
-Provider errors, if any, remain part of that raw record and are not treated as a
-successful review.
-
 A defensible next experiment would freeze a task-description-only policy generator
 and an unseen OpenAgentSafety subset, then compare ActPlane with an official,
 independently implemented runtime policy method under the same tasks, model,


### PR DESCRIPTION
## Summary
- require agent development and experiments on a non-default branch
- require a pull request for anything entering master
- remove only the checkout-local no-branch enforcement rule
- retain no-git-branch templates, examples, docs, and test fixtures as product demonstrations
- audit recoverable OpenAgentSafety evidence across the documented main and nested backup refs

## Validation
- target/release/actplane --policy actplane.yaml compile
- cargo test -p actplane templates::tests::all_templates_compile_as_dsl_and_yaml
- git diff --check
- nested backup ref resolves to 8cb4131211435a933d44942479e79418972f8f9b

## Research finding
The nested backup retains official per-task benchmark trajectories and evaluator outputs, but not the ActPlane-condition watcher logs, runner summaries, or paired trajectories underlying the aggregate 78/28 result. This narrows the recoverable evidence without claiming a trace-level ActPlane audit or an independent policy-system baseline.

## History note
Reviewer-audit commits through 54052ae2 reached master before this workflow correction. This PR does not rewrite or revert that published history. Further reviewer experiments continue on this branch and enter master only through reviewable PR updates.