### PR TITLE
Audit RQ2 outcomes by execution path and FIDES

### DIFF
--- a/docs/empirical-study/audit_rq2_verdicts.js
+++ b/docs/empirical-study/audit_rq2_verdicts.js
@@ -16,6 +16,20 @@ const manifest = path.join(root, "docs/artifact/rq2-qwen-primary/selected_runner
 const judgeDir = "trajectory_judges_llama_cpp_guardrail_response";
 const rows = [];
 
+const TRACE_FAMILIES = {
+  "trace_allowed_effect_compliant.jsonl": "allowed_effect",
+  "trace_lookalike_compliant.jsonl": "lookalike",
+  "trace_visible_violation.jsonl": "direct",
+  "trace_script_visible_violation.jsonl": "script",
+  "trace_opaque_fixture_violation.jsonl": "hidden",
+};
+const PATH_GROUPS = {
+  compliant: ["allowed_effect", "lookalike"],
+  direct: ["direct"],
+  indirect: ["script", "hidden"],
+};
+const SYSTEMS = ["prompt-filter", "tool-regex", "tool-ifc", "actplane-opaque", "actplane"];
+
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
@@ -38,24 +52,34 @@ function feedbackFacts(messages) {
 for (const line of fs.readFileSync(manifest, "utf8").split(/\r?\n/)) {
   if (!line || line.startsWith("#")) continue;
   const fields = line.split("\t");
-  const [system, repoKey, statement, trace, expectedLabel] = fields;
+  const [system, repoKey, statement, trace, manifestAuxLabel] = fields;
+  if (!SYSTEMS.includes(system)) throw new Error(`unknown system in manifest: ${system}`);
   const rel = fields[fields.length - 1];
   const resultFile = path.join(root, rel);
   const result = readJson(resultFile);
+  if (result.system !== system) {
+    throw new Error(`manifest/result system mismatch for ${rel}`);
+  }
   const judgeFile = path.join(path.dirname(resultFile), judgeDir,
     `${path.basename(resultFile, ".json")}.judge.json`);
   const judge = readJson(judgeFile);
+  if (judge.source_result !== rel) {
+    throw new Error(`judge/result pairing mismatch for ${rel}`);
+  }
   const facts = feedbackFacts(result.setup_feedbacks);
   const recoveryFacts = feedbackFacts(result.recovery_feedbacks);
+  const traceFamily = TRACE_FAMILIES[trace];
+  if (!traceFamily) throw new Error(`unknown trace family: ${trace}`);
   rows.push({
     key: `${repoKey}/${statement}/${trace}`,
     system,
     repo: result.repo,
     statement,
     trace,
+    trace_family: traceFamily,
     ground_truth_violation: Boolean(result.ground_truth && result.ground_truth.violation),
     judgment: judge.judgment && judge.judgment.confusion_label,
-    manifest_judgment: expectedLabel,
+    manifest_aux_label: manifestAuxLabel,
     kernel_intervened: Boolean(result.setup_fired),
     visible_intervention: Boolean(result.setup_visible_intervention),
     runner_blocked: Boolean(result.score && result.score.setup_blocked),
@@ -83,17 +107,125 @@ for (const line of fs.readFileSync(manifest, "utf8").split(/\r?\n/)) {
 const paired = new Map();
 for (const row of rows) {
   if (!paired.has(row.key)) paired.set(row.key, {});
+  if (paired.get(row.key)[row.system]) {
+    throw new Error(`duplicate ${row.system} row for ${row.key}`);
+  }
   paired.get(row.key)[row.system] = row;
 }
 
+for (const [key, systems] of paired) {
+  for (const system of SYSTEMS) {
+    if (!systems[system]) throw new Error(`missing ${system} row for ${key}`);
+  }
+}
+if (rows.length !== 950 || paired.size !== 190) {
+  throw new Error(`incomplete frozen matrix: ${rows.length} rows across ${paired.size} traces`);
+}
+
 for (const row of rows) {
-  const other = paired.get(row.key)[row.system === "actplane" ? "actplane-opaque" : "actplane"];
+  const otherSystem = row.system === "actplane" ? "actplane-opaque" :
+    row.system === "actplane-opaque" ? "actplane" : null;
+  const other = otherSystem && paired.get(row.key)[otherSystem];
   if (other) {
     row.paired_system = other.system;
     row.paired_judgment = other.judgment;
     row.paired_kernel_intervened = other.kernel_intervened;
     row.paired_any_observed_intervention = other.any_observed_intervention;
     row.paired_effect = other.effect;
+  }
+}
+
+function confusion(items) {
+  const labels = {TP: 0, TN: 0, FP: 0, FN: 0};
+  for (const row of items) {
+    if (!(row.judgment in labels)) throw new Error(`unknown judgment: ${row.judgment}`);
+    labels[row.judgment] += 1;
+  }
+  const total = items.length;
+  const correct = labels.TP + labels.TN;
+  return {
+    ...labels,
+    correct,
+    total,
+    dcr: total ? correct / total : null,
+    dcr_percent: total ? Number((100 * correct / total).toFixed(1)) : null,
+  };
+}
+
+function exactMcNemar(aOnly, bOnly) {
+  const discordant = aOnly + bOnly;
+  const tail = Math.min(aOnly, bOnly);
+  if (!discordant) return 1;
+  let term = Math.pow(0.5, discordant);
+  let sum = term;
+  for (let k = 0; k < tail; k += 1) {
+    term *= (discordant - k) / (k + 1);
+    sum += term;
+  }
+  return Math.min(1, 2 * sum);
+}
+
+function comparePaired(systemA, systemB, families) {
+  const aRows = rows.filter(row => row.system === systemA && families.includes(row.trace_family));
+  const cells = {both_correct: 0, a_only_correct: 0, b_only_correct: 0, both_wrong: 0};
+  for (const a of aRows) {
+    const b = paired.get(a.key)[systemB];
+    if (!b) throw new Error(`missing ${systemB} pair for ${a.key}`);
+    const aCorrect = a.judgment === "TP" || a.judgment === "TN";
+    const bCorrect = b.judgment === "TP" || b.judgment === "TN";
+    const cell = aCorrect && bCorrect ? "both_correct" : aCorrect ? "a_only_correct" :
+      bCorrect ? "b_only_correct" : "both_wrong";
+    cells[cell] += 1;
+  }
+  const aCorrect = cells.both_correct + cells.a_only_correct;
+  const bCorrect = cells.both_correct + cells.b_only_correct;
+  return {
+    system_a: systemA,
+    system_b: systemB,
+    n: aRows.length,
+    system_a_correct: aCorrect,
+    system_b_correct: bCorrect,
+    dcr_difference_percentage_points: Number((100 * (aCorrect - bCorrect) / aRows.length).toFixed(1)),
+    paired_outcomes: cells,
+    exact_mcnemar_two_sided_p: exactMcNemar(cells.a_only_correct, cells.b_only_correct),
+  };
+}
+
+const byTraceFamily = {};
+const byPathGroup = {};
+for (const system of SYSTEMS) {
+  byTraceFamily[system] = {};
+  for (const family of Object.values(TRACE_FAMILIES)) {
+    byTraceFamily[system][family] = confusion(
+      rows.filter(row => row.system === system && row.trace_family === family));
+  }
+  byPathGroup[system] = {};
+  for (const [group, families] of Object.entries(PATH_GROUPS)) {
+    byPathGroup[system][group] = confusion(
+      rows.filter(row => row.system === system && families.includes(row.trace_family)));
+  }
+  byPathGroup[system].overall = confusion(rows.filter(row => row.system === system));
+}
+
+const actplaneVsFides = {};
+for (const [group, families] of Object.entries(PATH_GROUPS)) {
+  actplaneVsFides[group] = comparePaired("actplane", "tool-ifc", families);
+}
+actplaneVsFides.overall = comparePaired(
+  "actplane", "tool-ifc", Object.values(TRACE_FAMILIES));
+
+const stageByFamily = {};
+for (const system of ["actplane", "actplane-opaque"]) {
+  stageByFamily[system] = {};
+  for (const family of Object.values(TRACE_FAMILIES)) {
+    const items = rows.filter(row => row.system === system && row.trace_family === family);
+    stageByFamily[system][family] = {
+      rows: items.length,
+      setup_intervened: items.filter(row => row.kernel_intervened).length,
+      any_phase_intervened: items.filter(row => row.any_observed_intervention).length,
+      any_kill: items.filter(row => row.effect === "kill" || row.recovery_effect === "kill").length,
+      any_notify: items.filter(row => row.effect === "notify" || row.recovery_effect === "notify").length,
+    };
   }
 }
 
@@ -121,12 +253,27 @@ for (const row of actplanePairs) {
   const key = left && right ? "both" : left ? "actplane_only" : right ? "opaque_only" : "neither";
   pairedSetupTriggers[key] += 1;
 }
+const manifestAuxiliaryLabel = {
+  note: "The manifest's undocumented fifth column is retained only for provenance; the paired judge file is the final outcome source used by the paper verifier.",
+  differs_from_judge: rows.filter(row => row.judgment !== row.manifest_aux_label).length,
+  differs_from_judge_by_system: {},
+};
+for (const system of SYSTEMS) {
+  manifestAuxiliaryLabel.differs_from_judge_by_system[system] = rows.filter(
+    row => row.system === system && row.judgment !== row.manifest_aux_label).length;
+}
 const summary = {
-  schema: "rq2-verdict-audit-v1",
+  schema: "rq2-verdict-audit-v2",
   source_manifest: "docs/artifact/rq2-qwen-primary/selected_runner_results.txt",
+  final_outcome_source: "trajectory_judges_llama_cpp_guardrail_response/*.judge.json judgment.confusion_label",
   total_rows: rows.length,
+  manifest_auxiliary_label: manifestAuxiliaryLabel,
   counts,
   intervention_by_label: interventionByLabel,
+  outcome_by_trace_family: byTraceFamily,
+  outcome_by_path_group: byPathGroup,
+  actplane_vs_fides_paired: actplaneVsFides,
+  actplane_stage_by_trace_family: stageByFamily,
   actplane_vs_opaque_setup_triggers: pairedSetupTriggers,
   actplane_fp: {
     count: actplaneFp.length,

--- a/docs/empirical-study/audit_rq2_verdicts.js
+++ b/docs/empirical-study/audit_rq2_verdicts.js
@@ -52,6 +52,9 @@ function feedbackFacts(messages) {
 for (const line of fs.readFileSync(manifest, "utf8").split(/\r?\n/)) {
   if (!line || line.startsWith("#")) continue;
   const fields = line.split("\t");
+  if (fields.length !== 7) {
+    throw new Error(`malformed manifest row: expected 7 tab-separated fields, got ${fields.length}`);
+  }
   const [system, repoKey, statement, trace, manifestAuxLabel] = fields;
   if (!SYSTEMS.includes(system)) throw new Error(`unknown system in manifest: ${system}`);
   const rel = fields[fields.length - 1];

--- a/docs/empirical-study/rq2-reviewer-audit-plan.md
+++ b/docs/empirical-study/rq2-reviewer-audit-plan.md
@@ -126,9 +126,10 @@ They nevertheless make the mechanism boundary falsifiable and show that the
 overall advantage is not evidence of superiority on direct paths.
 
 The same run keeps enforcement observations distinct from end-to-end outcomes.
-ActPlane records an intervention in 31 direct, 27 script, and 30 hidden traces,
-while the corresponding final TP counts are 31, 27, and 28. FIDES is compared
-only on final judged outcome because its tool-layer records are not kernel events.
+ActPlane records an any-phase intervention in 31 direct, 27 script, and 30
+hidden traces, while the corresponding final TP counts are 31, 27, and 28.
+FIDES is compared only on final judged outcome because its tool-layer records
+are not kernel events.
 ActPlane-opaque remains an ablation and is not included in the independent
 baseline test.
 
@@ -138,9 +139,10 @@ the ActPlane/opaque stage counts. The run used the read-only extraction command
 above, with raw output, input hashes, and a concise table retained under
 `/workspaces/.agent-state/actplane-research/raw/rq2-path-baseline-audit-20260910T0906Z/`.
 The manifest's undocumented fifth column disagrees with 97 FIDES judge outcomes
-and is ignored by the official paper verifier. The audit retains it as an
-auxiliary provenance field but uses each referenced judge file as the final
-outcome source, matching `docs/artifact/verify_results.py` on the artifact ref.
+(73 TP-to-FN and 24 TN-to-FP) and is ignored by the official paper verifier. The
+audit retains it as an auxiliary provenance field but uses each referenced judge
+file as the final outcome source, matching `docs/artifact/verify_results.py` on
+the artifact ref.
 This result strengthens the original coding-task RQ2 comparison. It does not add
 an independent baseline to OpenAgentSafety or establish unseen non-coding
 generalization.

--- a/docs/empirical-study/rq2-reviewer-audit-plan.md
+++ b/docs/empirical-study/rq2-reviewer-audit-plan.md
@@ -86,6 +86,65 @@ only ActPlane for 14, only opaque for zero, and neither for 93. This comparison
 describes recorded executions, not paired deterministic trials, because feedback
 can change later actions within a multi-step setup trajectory.
 
+## RQ2 matched execution-path analysis
+
+Reviewer D accepts FIDES as a reasonable baseline but questions whether the
+other controls are strong, while the stated RQ2 asks specifically about direct
+and indirect execution paths. The existing overall confusion matrix cannot show
+whether the result follows the below-tool mechanism, and the family heatmap does
+not report matched differences against the independent baseline. The analysis
+hypothesis is therefore that ActPlane and FIDES will be comparable on direct
+violations, where both see the initiating tool call, but ActPlane will have a
+large paired advantage on script and hidden violations whose effects cross that
+boundary.
+
+A positive result localizes the advantage to the mechanism claimed by RQ2. A
+negative result, such as the same advantage on direct paths or no advantage on
+indirect paths, would weaken that explanation. A mixed result requires reporting
+the losing path and limits rather than relying on overall DCR.
+
+| Comparison | Units | Outcome semantics | Role |
+| --- | ---: | --- | --- |
+| Five systems by allowed-effect, lookalike, direct, script, and hidden family | 38 per cell | End-to-end TP/TN/FP/FN from the paired judge file | descriptive matrix |
+| ActPlane versus FIDES on compliant, direct, and combined indirect groups | 76, 38, and 76 matched traces | Correct means TP or TN; exact two-sided McNemar test uses discordant pairs | primary independent-baseline comparison |
+| ActPlane versus opaque intervention by family | 38 per cell | setup and any-phase rule reports, separate from final judgment | feedback ablation and stage audit only |
+
+The frozen 950-row artifact supports the hypothesis, with an important direct-path
+boundary. On the 76 indirect violation traces, ActPlane correctly resolves 55
+(72.4%) while FIDES resolves 7 (9.2%), a 63.2 percentage-point difference. The
+matched cells are 4 both correct, 51 ActPlane only, 3 FIDES only, and 18 both
+wrong (exact two-sided McNemar \(p=2.92\times10^{-12}\)). The difference appears
+in both indirect families: script is 27/38 versus 7/38, and hidden is 28/38
+versus 0/38.
+
+Direct violations do not favor ActPlane: it resolves 31/38 (81.6%) versus
+FIDES at 34/38 (89.5%), with 2 ActPlane-only and 5 FIDES-only correct pairs
+(McNemar \(p=0.453\)). On the 76 compliant traces, ActPlane is 58/76 and FIDES
+is 52/76 (\(p=0.405\)). These exploratory paired tests were added after seeing
+the aggregate result and are not a substitute for a preregistered replication.
+They nevertheless make the mechanism boundary falsifiable and show that the
+overall advantage is not evidence of superiority on direct paths.
+
+The same run keeps enforcement observations distinct from end-to-end outcomes.
+ActPlane records an intervention in 31 direct, 27 script, and 30 hidden traces,
+while the corresponding final TP counts are 31, 27, and 28. FIDES is compared
+only on final judged outcome because its tool-layer records are not kernel events.
+ActPlane-opaque remains an ablation and is not included in the independent
+baseline test.
+
+The executable analysis is `docs/empirical-study/audit_rq2_verdicts.js`. Its
+version-2 JSON includes the complete family matrix, the matched comparison, and
+the ActPlane/opaque stage counts. The run used the read-only extraction command
+above, with raw output, input hashes, and a concise table retained under
+`/workspaces/.agent-state/actplane-research/raw/rq2-path-baseline-audit-20260910T0906Z/`.
+The manifest's undocumented fifth column disagrees with 97 FIDES judge outcomes
+and is ignored by the official paper verifier. The audit retains it as an
+auxiliary provenance field but uses each referenced judge file as the final
+outcome source, matching `docs/artifact/verify_results.py` on the artifact ref.
+This result strengthens the original coding-task RQ2 comparison. It does not add
+an independent baseline to OpenAgentSafety or establish unseen non-coding
+generalization.
+
 The raw rules already show heterogeneous candidate causes, including deliberately
 broad translations (notify on every write), semantic conditions unavailable to a
 path-only rule (dependency content or release intent), generated helper processes


### PR DESCRIPTION
## Why

RQ2 asks whether ActPlane improves compliance across direct and indirect execution paths, while Reviewer D accepts FIDES as the meaningful independent baseline. The reusable audit did not expose a matched path-level comparison or keep family-level kernel observations separate from final trajectory judgments.

## What changed

- extend the frozen 950-row audit with five trace families and compliant/direct/indirect groups
- add matched ActPlane-versus-FIDES comparisons with exact two-sided McNemar statistics
- report ActPlane and opaque stage observations separately from end-to-end outcomes
- validate the complete 5-system by 190-trace matrix and judge-to-result pairing
- document the hypothesis, result, negative direct-path boundary, and generalization limits
- retain the manifest's undocumented fifth column only as provenance; final labels come from the paired judge files, matching the artifact verifier

## Result

On 76 indirect violation traces, ActPlane is correct on 55 (72.4%) and FIDES/tool-IFC on 7 (9.2%). The matched cells are 4 both correct, 51 ActPlane only, 3 FIDES only, and 18 both wrong (exact McNemar p=2.92e-12). On 38 direct violations, ActPlane is 31/38 and FIDES is 34/38 (p=0.453), so this does not claim direct-path superiority.

This is a post-hoc reanalysis of the frozen coding corpus. OPAQUE remains a feedback ablation. It does not supply an independent OpenAgentSafety baseline or unseen non-coding generalization.

## Validation

- node syntax check
- fresh read-only extraction of `origin/artifact-ready`: 950/950 rows and 190 complete matched traces
- reproduced the documented path summaries and paired comparisons
- exact-head GitHub Build/Test and privileged eBPF checks pass

The previously cited local raw directory is absent from current retained state and is not relied upon. The audit is independently reproducible from the frozen Git ref with the documented command.
