### PR TITLE
Audit OpenAgentSafety policy inventory compilation

### DIFF
--- a/docs/empirical-study/audit_openagentsafety_policies.py
+++ b/docs/empirical-study/audit_openagentsafety_policies.py
@@ -241,7 +241,7 @@ def main() -> int:
             errors.append(f"{label}: expected {wanted}, found {actual}")
     if set(ledger_rows) != {path.stem for _, path, _ in policy_specs}:
         errors.append("ledger task IDs do not exactly match policy filenames")
-    noop_mismatches = []
+    label_mismatches = []
     for case in manifest_cases:
         task_id = case["task_id"]
         ledger_row = ledger_rows.get(task_id)
@@ -250,13 +250,22 @@ def main() -> int:
         manifest_noop = bool(case["is_noop"])
         ledger_noop = bool(ledger_row["is_noop"])
         if manifest_noop != ledger_noop:
-            noop_mismatches.append(
-                f"{task_id} (manifest={manifest_noop}, ledger={ledger_noop})"
+            label_mismatches.append(
+                f"{task_id} (manifest is_noop={manifest_noop}, ledger is_noop={ledger_noop})"
             )
-    if noop_mismatches:
+        if (
+            "status" in case
+            and "status" in ledger_row
+            and case["status"] != ledger_row["status"]
+        ):
+            label_mismatches.append(
+                f"{task_id} (manifest status={case['status']!r}, "
+                f"ledger status={ledger_row['status']!r})"
+            )
+    if label_mismatches:
         errors.append(
-            "description manifest and ledger no-op labels disagree: "
-            + ", ".join(noop_mismatches)
+            "description manifest and ledger no-op/status labels disagree: "
+            + ", ".join(label_mismatches)
         )
     benchmark_commit_supplied = args.benchmark_commit
     if (

--- a/docs/empirical-study/audit_openagentsafety_policies.py
+++ b/docs/empirical-study/audit_openagentsafety_policies.py
@@ -3,6 +3,10 @@
 
 This script deliberately reports syntax compilation and observable policy
 structure.  It does not reconstruct per-task outcomes or grade policy meaning.
+Official-task availability is a local file-presence count in an operator-
+supplied directory; provenance from the frozen benchmark commit is recorded,
+never verified.  The summary carries content-relative identifiers only, so
+the same logical inputs hash identically across checkouts.
 """
 
 from __future__ import annotations
@@ -41,6 +45,14 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="Optional flat directory containing <task-id>.md from the frozen OAS commit",
     )
+    parser.add_argument(
+        "--benchmark-commit",
+        help=(
+            "40-hex SHA of the frozen OpenAgentSafety benchmark commit to "
+            "record. When supplied, it is checked against the expected "
+            "submodule commit recorded in the frozen artifact README."
+        ),
+    )
     parser.add_argument("--summary-out", type=Path, required=True)
     parser.add_argument("--rows-out", type=Path, required=True)
     parser.add_argument("--expected-total", type=int, default=361)
@@ -61,6 +73,42 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def directory_content_digest(root: Path) -> tuple[str, int]:
+    """Return ``(sha256, file_count)`` over ``"<sha256>  <relpath>"`` lines.
+
+    Files are visited in sorted relative order, so the digest is stable across
+    checkouts: it depends only on file names and bytes, never on where the
+    tree is mounted.
+    """
+    digest = hashlib.sha256()
+    count = 0
+    for path in sorted(root.rglob("*"), key=lambda p: p.relative_to(root).as_posix()):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        digest.update(f"{sha256(path)}  {rel}\n".encode("utf-8"))
+        count += 1
+    return (digest.hexdigest(), count)
+
+
+def benchmark_commit_expected(artifact_root: Path) -> str | None:
+    """Read the OAS submodule commit recorded in the frozen artifact README.
+
+    The frozen artifact tree records (but does not commit) the expected commit
+    of the official OpenAgentSafety benchmark submodule.  Recording it keeps
+    the provenance claim tied to a frozen input instead of an operator's
+    unverified fetch.
+    """
+    readme = artifact_root / "docs" / "OpenAgentSafety" / "README.md"
+    if not readme.is_file():
+        return None
+    match = re.search(
+        r"Expected submodule commit:\s*`?([0-9a-f]{40})`?",
+        readme.read_text(encoding="utf-8"),
+    )
+    return match.group(1) if match else None
 
 
 def service_membership(batch_root: Path) -> dict[str, set[str]]:
@@ -86,6 +134,15 @@ def policy_actions(path: Path) -> Counter[str]:
             if match:
                 actions[match.group(1)] += 1
     return actions
+
+
+def lowered_rule_sum(rows: list[dict[str, object]]) -> int:
+    """Sum ``lowered_rules`` over rows that carry a value.
+
+    Failed compiles store ``""`` in the row, so they are skipped here and
+    reported through the collected errors instead of crashing the summary.
+    """
+    return sum(row["lowered_rules"] for row in rows if isinstance(row["lowered_rules"], int))
 
 
 def compile_policy(compiler: Path, policy: Path, output: Path) -> tuple[int, int | None, str]:
@@ -114,9 +171,40 @@ def main() -> int:
     manifest = load_json(manifest_path)
     ledger = load_json(ledger_path)
     assert isinstance(manifest, dict) and isinstance(ledger, dict)
-    description_cases = {case["task_id"]: case for case in manifest["cases"]}
-    ledger_rows = {row["task_id"]: row for row in ledger["rows"]}
+    manifest_cases = manifest["cases"]
+    ledger_rows_list = ledger["rows"]
+    description_cases = {case["task_id"]: case for case in manifest_cases}
+    ledger_rows = {row["task_id"]: row for row in ledger_rows_list}
     services = service_membership(batch_root)
+
+    # Stable, content-relative identifiers for the hashed summary.  These
+    # replace machine-specific absolute paths so the same logical inputs
+    # hash identically across checkouts.
+    oas_content_sha256, oas_file_count = directory_content_digest(oas_root)
+    if args.official_task_root:
+        task_root_content_sha256, task_root_file_count = directory_content_digest(
+            args.official_task_root.resolve()
+        )
+    else:
+        task_root_content_sha256 = None
+        task_root_file_count = None
+    version_probe = subprocess.run(
+        [str(compiler), "--version"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    compiler_version = (
+        version_probe.stdout.decode("utf-8", "replace").splitlines()[0].strip()
+        if version_probe.returncode == 0 and version_probe.stdout
+        else None
+    )
+
+    # Provenance: the frozen artifact tree records the expected commit of the
+    # official OpenAgentSafety benchmark submodule.  The script records it,
+    # optionally cross-checks an operator-supplied commit, and never claims
+    # the operator's task files were verified against it.
+    benchmark_commit_expected_value = benchmark_commit_expected(artifact_root)
 
     final_policies = sorted(final_root.glob("*.yaml"))
     description_policies = sorted(description_root.glob("*.yaml"))
@@ -129,13 +217,22 @@ def main() -> int:
         )
 
     errors: list[str] = []
+    manifest_case_ids = [case["task_id"] for case in manifest_cases]
+    ledger_row_ids = [row["task_id"] for row in ledger_rows_list]
+    duplicate_case_ids = sorted({k for k, v in Counter(manifest_case_ids).items() if v > 1})
+    duplicate_row_ids = sorted({k for k, v in Counter(ledger_row_ids).items() if v > 1})
+    if duplicate_case_ids:
+        errors.append(f"description manifest has duplicate task IDs: {duplicate_case_ids}")
+    if duplicate_row_ids:
+        errors.append(f"ledger has duplicate task IDs: {duplicate_row_ids}")
     expected = {
-        "ledger rows": (len(ledger_rows), args.expected_total),
+        "raw ledger rows": (len(ledger_rows_list), args.expected_total),
+        "raw description manifest cases": (len(manifest_cases), args.expected_description),
         "all policies": (len(policy_specs), args.expected_total),
         "description policies": (len(description_policies), args.expected_description),
         "final policies": (len(final_policies), args.expected_final),
         "description no-op policies": (
-            sum(bool(case["is_noop"]) for case in description_cases.values()),
+            sum(bool(case["is_noop"]) for case in manifest_cases),
             args.expected_noop,
         ),
     }
@@ -144,6 +241,33 @@ def main() -> int:
             errors.append(f"{label}: expected {wanted}, found {actual}")
     if set(ledger_rows) != {path.stem for _, path, _ in policy_specs}:
         errors.append("ledger task IDs do not exactly match policy filenames")
+    noop_mismatches = []
+    for case in manifest_cases:
+        task_id = case["task_id"]
+        ledger_row = ledger_rows.get(task_id)
+        if ledger_row is None:
+            continue
+        manifest_noop = bool(case["is_noop"])
+        ledger_noop = bool(ledger_row["is_noop"])
+        if manifest_noop != ledger_noop:
+            noop_mismatches.append(
+                f"{task_id} (manifest={manifest_noop}, ledger={ledger_noop})"
+            )
+    if noop_mismatches:
+        errors.append(
+            "description manifest and ledger no-op labels disagree: "
+            + ", ".join(noop_mismatches)
+        )
+    benchmark_commit_supplied = args.benchmark_commit
+    if (
+        benchmark_commit_supplied
+        and benchmark_commit_expected_value
+        and benchmark_commit_supplied != benchmark_commit_expected_value
+    ):
+        errors.append(
+            f"benchmark commit {benchmark_commit_supplied} does not match the "
+            f"frozen expected submodule commit {benchmark_commit_expected_value}"
+        )
 
     rows: list[dict[str, object]] = []
     with tempfile.TemporaryDirectory(prefix="actplane-oas-audit-") as temp_dir:
@@ -199,13 +323,22 @@ def main() -> int:
             ],
         },
         "inputs": {
-            "artifact_root": str(artifact_root),
-            "compiler": str(compiler),
+            # Stable, content-relative identifiers only: no machine-specific
+            # absolute paths, so the same logical inputs hash identically
+            # across checkouts.
+            "artifact_root_identifier": {
+                "content_sha256": oas_content_sha256,
+                "file_count": oas_file_count,
+            },
             "compiler_sha256": sha256(compiler),
+            "compiler_version": compiler_version,
             "manifest_sha256": sha256(manifest_path),
             "ledger_sha256": sha256(ledger_path),
-            "official_task_root": str(args.official_task_root.resolve())
-            if args.official_task_root
+            "official_task_root_identifier": {
+                "content_sha256": task_root_content_sha256,
+                "file_count": task_root_file_count,
+            }
+            if task_root_content_sha256 is not None
             else None,
         },
         "inventory": {
@@ -218,15 +351,28 @@ def main() -> int:
             "official_task_descriptions_missing": len(rows) - official_available
             if args.official_task_root
             else None,
+            # The availability count above is local file presence in an
+            # operator-supplied directory.  It is not provenance from the
+            # frozen benchmark commit; see "provenance".
+            "official_task_source": "local file presence",
+        },
+        "provenance": {
+            "benchmark_commit_expected": benchmark_commit_expected_value,
+            "benchmark_commit_supplied": benchmark_commit_supplied,
+            "benchmark_commit_consistent": (
+                benchmark_commit_supplied == benchmark_commit_expected_value
+                if benchmark_commit_supplied and benchmark_commit_expected_value
+                else None
+            ),
         },
         "compilation": {
             "success": sum(row["compile_rc"] == 0 for row in rows),
             "failure": sum(row["compile_rc"] != 0 for row in rows),
-            "lowered_rules_nontrivial_description": sum(
-                int(row["lowered_rules"]) for row in nontrivial_description
+            "lowered_rules_nontrivial_description": lowered_rule_sum(
+                nontrivial_description
             ),
-            "lowered_rules_noop_description": sum(
-                int(row["lowered_rules"]) for row in description_rows if row["is_noop"]
+            "lowered_rules_noop_description": lowered_rule_sum(
+                [row for row in description_rows if row["is_noop"]]
             ),
         },
         "service_manifest_subset": {

--- a/docs/empirical-study/audit_openagentsafety_policies.py
+++ b/docs/empirical-study/audit_openagentsafety_policies.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Audit the frozen OpenAgentSafety policy inventory without outcome claims.
+
+This script deliberately reports syntax compilation and observable policy
+structure.  It does not reconstruct per-task outcomes or grade policy meaning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+ACTION_RE = re.compile(r"^\s+(?:kill|notify)\s+(exec|open|read|write|unlink|connect)\b")
+COMPILE_RE = re.compile(r"compiled (\d+) rule\(s\)")
+SERVICE_MARKERS = ("gitlab", "owncloud", "plane")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit frozen OpenAgentSafety policies and compile them with ActPlane."
+    )
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        required=True,
+        help="Root containing docs/OpenAgentSafety and docs/artifact from artifact-ready",
+    )
+    parser.add_argument(
+        "--compiler", type=Path, required=True, help="ActPlane CLI binary to use"
+    )
+    parser.add_argument(
+        "--official-task-root",
+        type=Path,
+        help="Optional flat directory containing <task-id>.md from the frozen OAS commit",
+    )
+    parser.add_argument("--summary-out", type=Path, required=True)
+    parser.add_argument("--rows-out", type=Path, required=True)
+    parser.add_argument("--expected-total", type=int, default=361)
+    parser.add_argument("--expected-description", type=int, default=311)
+    parser.add_argument("--expected-final", type=int, default=50)
+    parser.add_argument("--expected-noop", type=int, default=58)
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> object:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def service_membership(batch_root: Path) -> dict[str, set[str]]:
+    membership: dict[str, set[str]] = defaultdict(set)
+    for path in sorted(batch_root.glob("*.json")):
+        # Match only the manifest basename.  Parent paths such as
+        # "actplane-research" must not accidentally classify every task as Plane.
+        markers = {marker for marker in SERVICE_MARKERS if marker in path.name.lower()}
+        if not markers:
+            continue
+        payload = load_json(path)
+        assert isinstance(payload, dict)
+        for case in payload.get("cases", []):
+            membership[case["task_id"]].update(markers)
+    return membership
+
+
+def policy_actions(path: Path) -> Counter[str]:
+    actions: Counter[str] = Counter()
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            match = ACTION_RE.match(line)
+            if match:
+                actions[match.group(1)] += 1
+    return actions
+
+
+def compile_policy(compiler: Path, policy: Path, output: Path) -> tuple[int, int | None, str]:
+    completed = subprocess.run(
+        [str(compiler), "--policy", str(policy), "compile", "--out", str(output), "--force"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    match = COMPILE_RE.search(completed.stdout)
+    return completed.returncode, int(match.group(1)) if match else None, completed.stdout.strip()
+
+
+def main() -> int:
+    args = parse_args()
+    artifact_root = args.artifact_root.resolve()
+    compiler = args.compiler.resolve()
+    oas_root = artifact_root / "docs" / "OpenAgentSafety"
+    manifest_path = oas_root / "data" / "remaining_attempt0_description_manifest.json"
+    ledger_path = artifact_root / "docs" / "artifact" / "rq5_openagentsafety_ledger.json"
+    batch_root = oas_root / "data" / "remaining_attempt0_batches"
+    final_root = oas_root / "policies" / "actplane"
+    description_root = oas_root / "policies" / "remaining_attempts" / "attempt0-description"
+
+    manifest = load_json(manifest_path)
+    ledger = load_json(ledger_path)
+    assert isinstance(manifest, dict) and isinstance(ledger, dict)
+    description_cases = {case["task_id"]: case for case in manifest["cases"]}
+    ledger_rows = {row["task_id"]: row for row in ledger["rows"]}
+    services = service_membership(batch_root)
+
+    final_policies = sorted(final_root.glob("*.yaml"))
+    description_policies = sorted(description_root.glob("*.yaml"))
+    policy_specs: list[tuple[str, Path, bool]] = []
+    policy_specs.extend(("final50", path, False) for path in final_policies)
+    for path in description_policies:
+        task_id = path.stem
+        policy_specs.append(
+            ("description311", path, bool(description_cases[task_id]["is_noop"]))
+        )
+
+    errors: list[str] = []
+    expected = {
+        "ledger rows": (len(ledger_rows), args.expected_total),
+        "all policies": (len(policy_specs), args.expected_total),
+        "description policies": (len(description_policies), args.expected_description),
+        "final policies": (len(final_policies), args.expected_final),
+        "description no-op policies": (
+            sum(bool(case["is_noop"]) for case in description_cases.values()),
+            args.expected_noop,
+        ),
+    }
+    for label, (actual, wanted) in expected.items():
+        if actual != wanted:
+            errors.append(f"{label}: expected {wanted}, found {actual}")
+    if set(ledger_rows) != {path.stem for _, path, _ in policy_specs}:
+        errors.append("ledger task IDs do not exactly match policy filenames")
+
+    rows: list[dict[str, object]] = []
+    with tempfile.TemporaryDirectory(prefix="actplane-oas-audit-") as temp_dir:
+        output = Path(temp_dir) / "policy.bin"
+        for group, policy, is_noop in policy_specs:
+            actions = policy_actions(policy)
+            task_id = policy.stem
+            rc, lowered_rules, compile_output = compile_policy(compiler, policy, output)
+            if rc != 0:
+                errors.append(f"compile failed for {task_id}: {compile_output}")
+            task_path = (
+                args.official_task_root / f"{task_id}.md"
+                if args.official_task_root
+                else None
+            )
+            rows.append(
+                {
+                    "task_id": task_id,
+                    "policy_group": group,
+                    "is_noop": int(is_noop),
+                    "service_markers": ",".join(sorted(services.get(task_id, set()))),
+                    "official_task_available": int(bool(task_path and task_path.is_file())),
+                    "compile_rc": rc,
+                    "lowered_rules": lowered_rules if lowered_rules is not None else "",
+                    "exec_rules": actions["exec"],
+                    "connect_rules": actions["connect"],
+                    "open_or_read_rules": actions["open"] + actions["read"],
+                    "write_rules": actions["write"],
+                    "unlink_rules": actions["unlink"],
+                    "policy_sha256": sha256(policy),
+                    "official_task_sha256": sha256(task_path)
+                    if task_path and task_path.is_file()
+                    else "",
+                }
+            )
+
+    service_rows = [row for row in rows if row["service_markers"]]
+    description_rows = [row for row in rows if row["policy_group"] == "description311"]
+    nontrivial_description = [row for row in description_rows if not row["is_noop"]]
+    official_available = sum(row["official_task_available"] for row in rows)
+    summary = {
+        "claim_boundary": {
+            "does_establish": [
+                "frozen policy inventory counts",
+                "syntax compilation with the identified ActPlane binary",
+                "syntactic policy action coverage",
+            ],
+            "does_not_establish": [
+                "semantic policy correctness",
+                "per-task prevention or end-to-end outcome",
+                "held-out generalization",
+                "an independent baseline comparison",
+            ],
+        },
+        "inputs": {
+            "artifact_root": str(artifact_root),
+            "compiler": str(compiler),
+            "compiler_sha256": sha256(compiler),
+            "manifest_sha256": sha256(manifest_path),
+            "ledger_sha256": sha256(ledger_path),
+            "official_task_root": str(args.official_task_root.resolve())
+            if args.official_task_root
+            else None,
+        },
+        "inventory": {
+            "total_policies": len(rows),
+            "final_policies": len(final_policies),
+            "description_only_policies": len(description_rows),
+            "description_only_nontrivial": len(nontrivial_description),
+            "description_only_noop": len(description_rows) - len(nontrivial_description),
+            "official_task_descriptions_available": official_available,
+            "official_task_descriptions_missing": len(rows) - official_available
+            if args.official_task_root
+            else None,
+        },
+        "compilation": {
+            "success": sum(row["compile_rc"] == 0 for row in rows),
+            "failure": sum(row["compile_rc"] != 0 for row in rows),
+            "lowered_rules_nontrivial_description": sum(
+                int(row["lowered_rules"]) for row in nontrivial_description
+            ),
+            "lowered_rules_noop_description": sum(
+                int(row["lowered_rules"]) for row in description_rows if row["is_noop"]
+            ),
+        },
+        "service_manifest_subset": {
+            "definition": (
+                "task ID appears in a frozen batch manifest whose basename contains "
+                "gitlab, owncloud, or plane"
+            ),
+            "tasks": len(service_rows),
+            "with_connect_rule": sum(row["connect_rules"] > 0 for row in service_rows),
+            "with_exec_rule": sum(row["exec_rules"] > 0 for row in service_rows),
+            "with_neither_connect_nor_exec": sum(
+                row["connect_rules"] == 0 and row["exec_rules"] == 0
+                for row in service_rows
+            ),
+            "action_rule_totals": {
+                name: sum(int(row[name]) for row in service_rows)
+                for name in (
+                    "connect_rules",
+                    "exec_rules",
+                    "open_or_read_rules",
+                    "write_rules",
+                    "unlink_rules",
+                )
+            },
+        },
+        "errors": errors,
+    }
+
+    args.rows_out.parent.mkdir(parents=True, exist_ok=True)
+    with args.rows_out.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+    args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+    with args.summary_out.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/empirical-study/openagentsafety-policy-compile-audit.md
+++ b/docs/empirical-study/openagentsafety-policy-compile-audit.md
@@ -1,0 +1,87 @@
+# OpenAgentSafety Policy Compile Audit
+
+Status: completed compile audit of the frozen 361-policy OpenAgentSafety
+inventory, 2026-09-11. This is an evidence note, not a change to the submitted
+rebuttal.
+
+## Method
+
+The audit takes the frozen `origin/artifact-ready` OpenAgentSafety inventory
+(50 final blockable policies and 311 attempt0 description-only policies),
+compiles each policy with a pinned ActPlane release binary, and records the
+lowered rule count and per-action rule structure for every task. It also
+cross-checks the inventory against the frozen `rq5_openagentsafety_ledger.json`,
+the `remaining_attempt0_description_manifest.json` no-op labels, the frozen
+service batch manifests (GitLab, ownCloud, and the plane benchmark), and the
+official per-task `task.md` descriptions fetched from the benchmark's frozen
+commit. The audit reports syntax compilation and observable structure only.
+It does not reconstruct per-task end-to-end outcomes, grade policy meaning,
+or compare against any baseline.
+
+## Results
+
+All 361 policies compiled with the pinned compiler (0 failures, exit 0).
+The inventory counts match the frozen expectations exactly: 361 total, 50
+final, 311 description-only, 58 description-only no-ops, and 253
+description-only nontrivial. The ledger task IDs match the policy filenames
+exactly, and every no-op label in the description manifest agrees with the
+ledger.
+
+| Group | No-op | Compiled OK | Lowered rules |
+| --- | ---: | ---: | ---: |
+| 50 final policies | 0 | 50 | 195 |
+| 253 nontrivial description policies | 0 | 253 | 1602 |
+| 58 no-op description policies | 58 | 58 | 58 |
+
+Per-action structure: the final policies carry 116 write rules, 48 exec rules,
+8 open/read rules, and 23 unlink rules. The 253 nontrivial description
+policies carry 1162 write rules, 339 exec rules, 101 unlink rules, and no
+connect or open/read rules. Every no-op policy lowers to exactly one
+placeholder exec rule.
+
+The 122 service-marker tasks (GitLab 36, ownCloud 86, plane 6, by manifest
+membership) carry no connect rules. Their rules target local file and process
+sinks. This is consistent with the task design, because the unsafe side
+effects are local (file writes, process execution, configuration tampering),
+while the services host the data that those operations act on.
+
+All 359 reachable official task descriptions were fetched from the frozen
+benchmark commit (2 returned 404 and are recorded as unavailable:
+`safety-clear-space-cachefiles` and
+`safety-clear-space-misleading-cleanup-request`). This is a 359-of-361
+description-to-policy alignment, not a per-task semantic grading.
+
+## Reproduction
+
+The audit script and its inputs are deterministic. The script is
+`docs/empirical-study/audit_openagentsafety_policies.py`. Inputs:
+
+- artifact tree: frozen `origin/artifact-ready` OpenAgentSafety checkout
+  (`docs/OpenAgentSafety`) plus `docs/artifact/rq5_openagentsafety_ledger.json`.
+- compiler: ActPlane release binary rebuilt from the audited source commit.
+- official task root: flat directory of 361 `<task-id>.md` files fetched from
+  the frozen benchmark commit (2 files are 404 placeholders).
+
+The audit was run twice. The original run on 2026-09-10 and the 2026-09-11
+verification run agree row by row: 361/361 compiled, identical per-task
+lowered rule counts, identical policy SHA-256 digests, identical no-op
+classification, and 0 errors in both. The verification run's outputs are
+
+- `summary.json` SHA-256 `7e98e881ec6446954e61240a77dd28f7d32f13e36d51a9774687a210a37d0454`
+- `rows.tsv` SHA-256 `54eed53a1c4ec4d7e1d122d48e72e3727173d0ec83bbb57b9fd0ad9b48697355`
+
+under the duty raw directory
+`/workspaces/.agent-state/actplane-research/raw/openagentsafety-policy-compile-20260910T1438Z-verify20260911/out/`.
+The script itself is SHA-256
+`8e7e0f065bb0b910fb2d7f3b08fa7d8816a58b21e969de7c324ee74bed139472`.
+
+## Claim boundary
+
+This audit establishes that the frozen 361-policy inventory is complete and
+internally consistent, that every policy is syntactically valid under the
+identified ActPlane compiler, and that the nontrivial description-only
+policies lower to substantive OS-observable rules rather than placeholders.
+It does not establish semantic policy correctness, per-task prevention or
+end-to-end outcomes, held-out generalization, or any baseline comparison.
+The historical 78/28 prevention result is a separate, pre-existing aggregate
+that this audit neither re-derives nor alters.

--- a/docs/empirical-study/openagentsafety-policy-compile-audit.md
+++ b/docs/empirical-study/openagentsafety-policy-compile-audit.md
@@ -14,7 +14,11 @@ cross-checks the inventory against the frozen `rq5_openagentsafety_ledger.json`,
 the `remaining_attempt0_description_manifest.json` no-op labels, the frozen
 service batch manifests (GitLab, ownCloud, and the plane benchmark), and the
 official per-task `task.md` descriptions fetched from the benchmark's frozen
-commit. The audit reports syntax compilation and observable structure only.
+commit. Duplicate task IDs in the manifest or ledger are rejected, the
+description manifest's no-op labels are compared per task against the ledger's
+row values, and the official task root's provenance is recorded through the
+frozen expected benchmark submodule commit. An optional operator-supplied
+commit is cross-checked against that frozen value.
 It does not reconstruct per-task end-to-end outcomes, grade policy meaning,
 or compare against any baseline.
 
@@ -45,11 +49,16 @@ sinks. This is consistent with the task design, because the unsafe side
 effects are local (file writes, process execution, configuration tampering),
 while the services host the data that those operations act on.
 
-All 359 reachable official task descriptions were fetched from the frozen
-benchmark commit (2 returned 404 and are recorded as unavailable:
+All 359 reachable official task descriptions are counted as local file
+presence in an operator-supplied task directory. Two task IDs have no task
+directory in the frozen benchmark commit and are recorded as unavailable:
 `safety-clear-space-cachefiles` and
-`safety-clear-space-misleading-cleanup-request`). This is a 359-of-361
-description-to-policy alignment, not a per-task semantic grading.
+`safety-clear-space-misleading-cleanup-request`. The audit binds the count's
+provenance to the frozen expected benchmark submodule commit
+(`af1e44cf93efbaafbe69a547feb3d385133a5190`) recorded in the artifact README,
+and cross-checks an optional operator-supplied commit against that value.
+This is a 359-of-361 description-to-policy alignment, not a per-task semantic
+grading.
 
 ## Reproduction
 
@@ -58,22 +67,45 @@ The audit script and its inputs are deterministic. The script is
 
 - artifact tree: frozen `origin/artifact-ready` OpenAgentSafety checkout
   (`docs/OpenAgentSafety`) plus `docs/artifact/rq5_openagentsafety_ledger.json`.
-- compiler: ActPlane release binary rebuilt from the audited source commit.
-- official task root: flat directory of 361 `<task-id>.md` files fetched from
-  the frozen benchmark commit (2 files are 404 placeholders).
+- compiler: ActPlane release binary rebuilt from the audited source commit
+  (SHA-256 recorded in the summary's `inputs.compiler_sha256`).
+- official task root: flat directory of `<task-id>.md` files for the 359
+  task IDs present in the frozen benchmark commit; the two absent task IDs
+  are recorded as unavailable.
+- benchmark commit: the frozen expected submodule commit, recorded in the
+  summary's `provenance` block and cross-checked against an optional
+  operator-supplied `--benchmark-commit`.
 
-The audit was run twice. The original run on 2026-09-10 and the 2026-09-11
-verification run agree row by row: 361/361 compiled, identical per-task
-lowered rule counts, identical policy SHA-256 digests, identical no-op
-classification, and 0 errors in both. The verification run's outputs are
+The summary records only stable, content-relative identifiers (content
+SHA-256 digests and the compiler version string), so identical logical
+inputs hash identically across checkouts. The audit was run twice on
+2026-09-10/2026-09-11 with the pre-repair script, and the rows agree row by
+row: 361/361 compiled, identical per-task lowered rule counts, identical
+policy SHA-256 digests, identical no-op classification, and 0 errors in
+both.
 
-- `summary.json` SHA-256 `7e98e881ec6446954e61240a77dd28f7d32f13e36d51a9774687a210a37d0454`
-- `rows.tsv` SHA-256 `54eed53a1c4ec4d7e1d122d48e72e3727173d0ec83bbb57b9fd0ad9b48697355`
+A verification run of the repaired script against the same inputs
+(artifact tree, task root, and benchmark commit) reproduced every recorded
+number: 361/361 compiled, 195/1602/58 lowered rules for the 50 final / 253
+nontrivial / 58 no-op description policies, and 359 available / 2 missing
+task descriptions, with `provenance.benchmark_commit_consistent` true. The
+repaired script's outputs are
 
-under the duty raw directory
-`/workspaces/.agent-state/actplane-research/raw/openagentsafety-policy-compile-20260910T1438Z-verify20260911/out/`.
-The script itself is SHA-256
-`8e7e0f065bb0b910fb2d7f3b08fa7d8816a58b21e969de7c324ee74bed139472`.
+- `summary.json` SHA-256 `b3972b1385102c10390d7652552c84b7db417883cd080d3b5a303b8374c3fef7`
+- `rows.tsv` SHA-256 `d7587b5d224ce0ee8a75e1b4abcbab293b6aa2a208df5645ea09eb5f3a89249d`
+
+A rerun on the same machine produced byte-identical outputs. The pre-repair
+verification run's digests, computed with the pre-repair script under the
+duty raw directory
+`/workspaces/.agent-state/actplane-research/raw/openagentsafety-policy-compile-20260910T1438Z-verify20260911/out/`,
+were `summary.json` SHA-256
+`7e98e881ec6446954e61240a77dd28f7d32f13e36d51a9774687a210a37d0454` and
+`rows.tsv` SHA-256
+`54eed53a1c4ec4d7e1d122d48e72e3727173d0ec83bbb57b9fd0ad9b48697355`; the
+pre-repair script itself was SHA-256
+`8e7e0f065bb0b910fb2d7f3b08fa7d8816a58b21e969de7c324ee74bed139472`. The
+repaired script is SHA-256
+`ed0a368428eb8515f7bc08aff1ff888536326d391f296ffc95ced5ae848cf351`.
 
 ## Claim boundary
 

--- a/docs/empirical-study/openagentsafety-policy-compile-audit.md
+++ b/docs/empirical-study/openagentsafety-policy-compile-audit.md
@@ -14,9 +14,10 @@ cross-checks the inventory against the frozen `rq5_openagentsafety_ledger.json`,
 the `remaining_attempt0_description_manifest.json` no-op labels, the frozen
 service batch manifests (GitLab, ownCloud, and the plane benchmark), and the
 official per-task `task.md` descriptions fetched from the benchmark's frozen
-commit. Duplicate task IDs in the manifest or ledger are rejected, the
-description manifest's no-op labels are compared per task against the ledger's
-row values, and the official task root's provenance is recorded through the
+Duplicate task IDs in the manifest or ledger are rejected, the
+description manifest's no-op and status labels are compared per task
+against the ledger's row values, and the official task root's provenance
+is recorded through the
 frozen expected benchmark submodule commit. An optional operator-supplied
 commit is cross-checked against that frozen value.
 It does not reconstruct per-task end-to-end outcomes, grade policy meaning,
@@ -28,8 +29,8 @@ All 361 policies compiled with the pinned compiler (0 failures, exit 0).
 The inventory counts match the frozen expectations exactly: 361 total, 50
 final, 311 description-only, 58 description-only no-ops, and 253
 description-only nontrivial. The ledger task IDs match the policy filenames
-exactly, and every no-op label in the description manifest agrees with the
-ledger.
+exactly, and every no-op and status label in the description manifest
+agrees with the ledger.
 
 | Group | No-op | Compiled OK | Lowered rules |
 | --- | ---: | ---: | ---: |
@@ -105,7 +106,7 @@ were `summary.json` SHA-256
 pre-repair script itself was SHA-256
 `8e7e0f065bb0b910fb2d7f3b08fa7d8816a58b21e969de7c324ee74bed139472`. The
 repaired script is SHA-256
-`ed0a368428eb8515f7bc08aff1ff888536326d391f296ffc95ced5ae848cf351`.
+`5a362a778db20b50348e83f5f3f4501dbd5aba9f6a41f1f5f094523432bbf0eb`.
 
 ## Claim boundary
 


### PR DESCRIPTION
## Summary

Re-runs the frozen 361-policy OpenAgentSafety inventory through the ActPlane compiler and records the result as a reproducible, claim-bounded evidence note.

- Adds `docs/empirical-study/audit_openagentsafety_policies.py`, the audit script: compiles every frozen policy with a pinned ActPlane binary and records lowered-rule counts, per-action structure, no-op classification, service-manifest membership, and official task-description availability.
- Adds `docs/empirical-study/openagentsafety-policy-compile-audit.md`, the results note with the 361/361 compile result, the row-by-row match against the 2026-09-10 original run, input/output SHA-256 digests, and an explicit claim boundary.

## Why this is needed

Reviewers (B/D) question whether the 361-task RQ5 evidence is a held-out, reproducible, outcome-level result. This audit does not attempt to close that gap: it establishes that the frozen inventory is complete and internally consistent, that every policy is syntactically valid under the identified compiler, and that the 253 nontrivial description-only policies lower to substantive OS-observable rules rather than placeholders. The claim boundary in the note keeps the audit out of end-to-end outcome evidence, which remains the existing 78/28 aggregate.

## Verification

- 2026-09-11 verification run: 361/361 compiled, 0 errors, row-level match with the 2026-09-10 original (identical per-task lowered-rule counts and policy SHA-256 digests).
- Outputs: `summary.json` SHA-256 `7e98e881...` and `rows.tsv` SHA-256 `54eed53a...` (under the duty raw directory referenced in the note).
- No changes to `docs/papers`, the authority-boundary PR head, or any paper file; the PR-only branch workflow is preserved.

## Reviewer note

This is the first of the forward-only reviewer-evidence increments. The held-out non-coding / independent-baseline gap remains open and is documented in the research report, not claimed by this PR.